### PR TITLE
A bug fix for auto-recovering data source.

### DIFF
--- a/Audjustable/Classes/AudioPlayer/AutoRecoveringHttpDataSource.m
+++ b/Audjustable/Classes/AudioPlayer/AutoRecoveringHttpDataSource.m
@@ -146,6 +146,8 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
     
     [self stopNotifier];
     
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+    
     if (reachabilityRef!= NULL)
     {
         CFRelease(reachabilityRef);


### PR DESCRIPTION
As it is at the moment, a hanging attemptReconnect invocation will probably crash if the data source got dealloced in the meantime.
