### PR TITLE
Stopped AudioPlayer from setting wrong state when resetting audio queue

### DIFF
--- a/Audjustable/Classes/AudioPlayer/AudioPlayer.m
+++ b/Audjustable/Classes/AudioPlayer/AudioPlayer.m
@@ -1410,7 +1410,11 @@ static void AudioQueueIsRunningCallbackProc(void* userData, AudioQueueRef audioQ
         
         if (currentlyReadingEntry == nil)
         {
-            self.internalState = AudioPlayerInternalStateStopping;
+			if (upcomingQueue.count == 0)
+			{
+				stopReason = AudioPlayerStopReasonNoStop;
+				self.internalState = AudioPlayerInternalStateStopping;
+			}
         }
         
         if (nextIsDifferent && entry)


### PR DESCRIPTION
When playing two incompatible files one after another, i.e. when the audio queue needs to reset, AudioPlayer incorrectly sets the internal state to Stopping, which can lead to the user of AudioPlayer to make wrong assumptions about playback.
