### PR TITLE
Fixing playback for short clips (fixes #43)

### DIFF
--- a/Audjustable/Classes/AudioPlayer/AudioPlayer.m
+++ b/Audjustable/Classes/AudioPlayer/AudioPlayer.m
@@ -2021,7 +2021,7 @@ static void AudioQueueIsRunningCallbackProc(void* userData, AudioQueueRef audioQ
             currentlyReadingEntry.bufferIndex = audioPacketsReadCount;
             currentlyReadingEntry = nil;
             
-            if (self.internalState == AudioPlayerInternalStatePlaying)
+            if (self.internalState | AudioPlayerInternalStateRunning)
             {
                 if (audioQueue)
                 {


### PR DESCRIPTION
Fixing playback of short clips (#43). I believe the file would finish downloading before the buffer was full enough to start playing. This makes the change to check for AudioPlayerInternalStateRunning when the file finishes downloading in order to start playback.

Def open to feedback if you think of a better way to do this.
