### PR TITLE
Using AudioQueueGetCurrentTime to get the playback progress.

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -1386,17 +1386,15 @@ static void AudioQueueIsRunningCallbackProc(void* userData, AudioQueueRef audioQ
     }
     
     OSSpinLockLock(&currentlyPlayingLock);
-    
-    STKQueueEntry* entry = currentlyPlayingEntry;
-    
-    if (entry == nil)
-    {
-    	OSSpinLockUnlock(&currentlyPlayingLock);
-        
-        return 0;
+
+    double retval = 0;
+    if(audioQueue && currentlyPlayingEntry) {
+        AudioTimeStamp timeStamp;
+        OSStatus status = AudioQueueGetCurrentTime(audioQueue, NULL, &timeStamp, NULL);
+        if (!status) {
+            retval = timeStamp.mSampleTime / currentlyPlayingEntry->audioStreamBasicDescription.mSampleRate;
+        }
     }
-    
-    double retval = [entry progress];
     
     OSSpinLockUnlock(&currentlyPlayingLock);
     


### PR DESCRIPTION
This results in finer detail (smoother progress-based animations!) and more accurate progress information. Should fix #52 and possibly #55.

I left `STKQueueEntry`'s `- (dobule)progress` method unmodified, since it might be useful to get the buffering progress of an entry..
