### PR TITLE
Add sharedManager Method

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -283,6 +283,17 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
 
 @implementation STKAudioPlayer
 
++(instancetype) sharedManager {
+    
+    static STKAudioPlayer *audioPlayer = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        audioPlayer = [[self alloc]init];
+    });
+    
+    return audioPlayer;
+}
+
 +(void) initialize
 {
     convertUnitDescription = (AudioComponentDescription)


### PR DESCRIPTION
STKAudioPlayer.m

Follow the the singleton pattern:
To access audioPlayer instance throughout the app, without having to pass the data around manually.

Solve the problem: https://github.com/tumtumtum/StreamingKit/issues/110

Access audioPlayer instance globally by using:
(for example)
[[STKAudioPlayer sharedManager] pause];

I think it's good for StreamingKit to have this feature.
