### PR TITLE
add public interface for sharedManager

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.h
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.h
@@ -263,4 +263,6 @@ typedef void(^STKFrameFilter)(UInt32 channelsPerFrame, UInt32 bytesPerFrame, UIn
 /// Sets the gain value (from -96 low to +24 high) for an equalizer band (0 based index)
 -(void) setGain:(float)gain forEqualizerBand:(int)bandIndex;
 
++(instancetype) sharedManager;
+
 @end


### PR DESCRIPTION
STKAudioPlayer.h

Follow the the singleton pattern:
To access audioPlayer instance throughout the app, without having to pass the data around manually.

Solve the problem: https://github.com/tumtumtum/StreamingKit/issues/110

Access audioPlayer instance globally by using:
(for example)
[[STKAudioPlayer sharedManager] pause];

I think it's good for StreamingKit to have this feature.
