### PR TITLE
Update STKAudioPlayer.m

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -2340,6 +2340,8 @@ OSStatus AudioConverterCallback(AudioConverterRef inAudioConverter, UInt32* ioNu
     
     while (true)
     {
+    	if(!currentlyReadingEntry) break;
+    	
         OSSpinLockLock(&pcmBufferSpinLock);
         UInt32 used = pcmBufferUsedFrameCount;
         UInt32 start = pcmBufferFrameStartIndex;
@@ -2353,6 +2355,8 @@ OSStatus AudioConverterCallback(AudioConverterRef inAudioConverter, UInt32* ioNu
             
             while (true)
             {
+            	if(!currentlyReadingEntry) break;
+            	
                 OSSpinLockLock(&pcmBufferSpinLock);
                 used = pcmBufferUsedFrameCount;
                 start = pcmBufferFrameStartIndex;


### PR DESCRIPTION
Was crashing every time I would stop and clear the buffers. My thought is that it was in the middle of reading some bytes while the currentlyReadingEntry was deallocated. OSSpinLock() would get called and would throw a BAD_ACCESS.
