### PR TITLE
NULLing eventsRunLoop may crash later

### DIFF
--- a/StreamingKit/StreamingKit/STKCoreFoundationDataSource.m
+++ b/StreamingKit/StreamingKit/STKCoreFoundationDataSource.m
@@ -137,8 +137,6 @@ static void ReadStreamCallbackProc(CFReadStreamRef stream, CFStreamEventType eve
     {
         CFReadStreamSetClient(stream, kCFStreamEventHasBytesAvailable | kCFStreamEventErrorOccurred | kCFStreamEventEndEncountered, NULL, NULL);
         CFReadStreamUnscheduleFromRunLoop(stream, [eventsRunLoop getCFRunLoop], kCFRunLoopCommonModes);
-        
-        eventsRunLoop = nil;
     }
 }
 


### PR DESCRIPTION
Because the STKAudioPlayer calls:

```
            [currentlyReadingEntry.dataSource unregisterForEvents];
            [currentlyReadingEntry.dataSource close];
```

Or when calling [close] and then [open] immediately

**Something happened to the previous PR https://github.com/tumtumtum/StreamingKit/pull/149 so this is a retry**
