### PR TITLE
Paused Audio Player doesn't transit to Stopped state on stop

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -2412,6 +2412,9 @@ static BOOL GetHardwareCodecClassDesc(UInt32 formatId, AudioClassDescription* cl
     }
     else if (!isRunning)
     {
+        stopReason = stopReasonIn;
+        self.internalState = STKAudioPlayerInternalStateStopped;
+
         return;
     }
     


### PR DESCRIPTION
If the Audio Player is paused and you call stop method, it doesn't transit to Stopped state.