### PR TITLE
Removing warnings

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -64,7 +64,7 @@
 #define STK_DEFAULT_GRACE_PERIOD_AFTER_SEEK_SECONDS (0.5)
 
 #define OSSTATUS_PRINTF_PLACEHOLDER @"%c%c%c%c"
-#define OSSTATUS_PRINTF_VALUE(status) ((status) >> 24) & 0xFF, ((status) >> 16) & 0xFF, ((status) >> 8) & 0xFF, (status) & 0xFF
+#define OSSTATUS_PRINTF_VALUE(status) (int)(((status) >> 24) & 0xFF), (int)(((status) >> 16) & 0xFF), (int)(((status) >> 8) & 0xFF), (int)((status) & 0xFF)
 
 #define LOGINFO(x) [self logInfo:[NSString stringWithFormat:@"%s %@", sel_getName(_cmd), x]];
 


### PR DESCRIPTION
Removing a bunch of format string type warnings by explicitly casting the macro results to int. (End up as long in some build platforms by default, which the compiler whinges about).