### PR TITLE
Update STKAudioPlayer.m

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -877,7 +877,7 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         }
 		case kAudioFileStreamProperty_ReadyToProducePackets:
         {
-			if (!audioConverterAudioStreamBasicDescription.mFormatID == kAudioFormatLinearPCM)
+			if (audioConverterAudioStreamBasicDescription.mFormatID != kAudioFormatLinearPCM)
 			{
 				discontinuous = YES;
 			}


### PR DESCRIPTION
The original line throws this warning in XCode - 
...../External Libraries/StreamingKit/StreamingKit/StreamingKit/STKAudioPlayer.m:880:61: Comparison of constant 'kAudioFormatLinearPCM' (1819304813) with boolean expression is always false

I'm guessing the precedence of ! vs == causes it to be 'mis-interpreted'.

Not quite sure of the logic where audio format != linear PCM implies a discontinuous stream, but...