### PR TITLE
fix reconnect to live streams

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -1947,7 +1947,7 @@ static BOOL GetHardwareCodecClassDesc(UInt32 formatId, AudioClassDescription* cl
 
     [self destroyAudioConverter];
     
-    canonicalAudioStreamBasicDescription.mChannelsPerFrame = asbd->mChannelsPerFrame;
+    //canonicalAudioStreamBasicDescription.mChannelsPerFrame = asbd->mChannelsPerFrame;
     
     BOOL isRecording = currentlyReadingEntry.dataSource.recordToFileUrl != nil;
     if (isRecording)

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -877,7 +877,7 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         }
 		case kAudioFileStreamProperty_ReadyToProducePackets:
         {
-			if (!audioConverterAudioStreamBasicDescription.mFormatID == kAudioFormatLinearPCM)
+			if (!(audioConverterAudioStreamBasicDescription.mFormatID == kAudioFormatLinearPCM))
 			{
 				discontinuous = YES;
 			}

--- a/StreamingKit/StreamingKit/STKHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKHTTPDataSource.m
@@ -411,7 +411,7 @@
     
     eventsRunLoop = savedEventsRunLoop;
 	
-    [self seekToOffset:self.position];
+    [self seekToOffset:self->supportsSeek ? self.position : 0];
 }
 
 -(void) seekToOffset:(SInt64)offset


### PR DESCRIPTION
seeking to a non-zero offset works only if seek is supported (accept-ranges header)