### PR TITLE
An ode to being a developer

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -470,10 +470,13 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         
         OSSpinLockUnlock(&internalStateLock);
         
-        dispatch_async(dispatch_get_main_queue(), ^
+        if ([self.delegate respondsToSelector:@selector(audioPlayer:stateChanged:previousState:)])
         {
-            [self.delegate audioPlayer:self stateChanged:self.state previousState:previousState];
-        });
+	        dispatch_async(dispatch_get_main_queue(), ^
+	        {
+	            [self.delegate audioPlayer:self stateChanged:self.state previousState:previousState];
+	        });
+        }
     }
     else
     {
@@ -971,7 +974,11 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
     
     [self playbackThreadQueueMainThreadSyncBlock:^
     {
-        [self.delegate audioPlayer:self unexpectedError:errorCodeIn];
+    
+	if ([self.delegate respondsToSelector:@selector(audioPlayer:unexpectedError:)])
+	{
+        	[self.delegate audioPlayer:self unexpectedError:errorCodeIn];
+        }
     }];
 }
 
@@ -1202,7 +1209,10 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         {
             [self playbackThreadQueueMainThreadSyncBlock:^
             {
-                [self.delegate audioPlayer:self didFinishPlayingQueueItemId:queueItemId withReason:stopReason andProgress:progress andDuration:duration];
+		if ([self.delegate respondsToSelector:@selector(audioPlayer:didFinishPlayingQueueItemId:withReason:andProgress:andDuration:)])
+		{
+                	[self.delegate audioPlayer:self didFinishPlayingQueueItemId:queueItemId withReason:stopReason andProgress:progress andDuration:duration];
+                }
             }];
         }
         
@@ -1212,7 +1222,10 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
             
             [self playbackThreadQueueMainThreadSyncBlock:^
             {
-                [self.delegate audioPlayer:self didStartPlayingQueueItemId:playingQueueItemId];
+		if ([self.delegate respondsToSelector:@selector(audioPlayer:didStartPlayingQueueItemId:)])
+		{
+                	[self.delegate audioPlayer:self didStartPlayingQueueItemId:playingQueueItemId];
+                }
             }];
         }
     }
@@ -1226,7 +1239,9 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         {
             [self playbackThreadQueueMainThreadSyncBlock:^
             {
-				[self.delegate audioPlayer:self didFinishPlayingQueueItemId:queueItemId withReason:stopReason andProgress:progress andDuration:duration];
+            	if ([self.delegate respondsToSelector:@selector(audioPlayer:didFinishPlayingQueueItemId:withReason:andProgress:andDuration:)]){
+            		[self.delegate audioPlayer:self didFinishPlayingQueueItemId:queueItemId withReason:stopReason andProgress:progress andDuration:duration];
+		}
             }];
         }
     }
@@ -1642,7 +1657,9 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
     
     [self dispatchSyncOnMainThread:^
     {
-        [self.delegate audioPlayer:self didFinishBufferingSourceWithQueueItemId:queueItemId];
+        if ([self.delegate respondsToSelector:@selector(audioPlayer:didFinishBufferingSourceWithQueueItemId:)]){
+        	[self.delegate audioPlayer:self didFinishBufferingSourceWithQueueItemId:queueItemId];
+        }
     }];
 
     pthread_mutex_lock(&playerMutex);

--- a/StreamingKit/StreamingKit/STKHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKHTTPDataSource.m
@@ -310,11 +310,7 @@
         
         self->iceHeaderData = nil;
     }
-    
-    if (([httpHeaders objectForKey:@"Accept-Ranges"] ?: [httpHeaders objectForKey:@"accept-ranges"]) != nil)
-    {
-        self->supportsSeek = YES;
-    }
+    self->supportsSeek = YES;
     
     if (self.httpStatusCode == 200)
     {


### PR DESCRIPTION
I understand this PR might look insane. I know it's a regression. It's crazy that we even live in a world where a PR like this is needed.

Lots of servers (Or should I say, lots of servers that *I* use), for some god forsaken reason, refuse to send the `Accept-Range` header. BUT, they still respond to seek requests. The feature is completely usable, it's just that they don't advertise.

 I call their hotlines, I email them, I'll even tweet, and they won't add it.

I imagine this PR is probably unhelpful, but to the people who live in a world with unfortunately shitty data, this may be useful. Worst that comes is it gets closed ¯\\\_(ツ)_/¯  or I could make it an option, but that has some architectural decisions with how this code is structured