### PR TITLE
Add +canonicalAudioStreamBasicDescription to access format of PCM data

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.h
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.h
@@ -175,6 +175,9 @@ typedef void(^STKFrameFilter)(UInt32 channelsPerFrame, UInt32 bytesPerFrame, UIn
 /// URLs with unrecognised schemes will return nil.
 +(STKDataSource*) dataSourceFromURL:(NSURL*)url;
 
+/// Returns canonical audio format used by STKFrameFilter blocks.
++(AudioStreamBasicDescription)canonicalAudioStreamBasicDescription;
+
 /// Initializes a new STKAudioPlayer with the default options
 -(instancetype) init;
 

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -680,6 +680,11 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
     return retval;
 }
 
++ (AudioStreamBasicDescription)canonicalAudioStreamBasicDescription
+{
+  return canonicalAudioStreamBasicDescription;
+}
+
 -(void) clearQueue
 {
     pthread_mutex_lock(&playerMutex);


### PR DESCRIPTION
This adds an accessor for canonicalAudioStreamBasicDescription, which describes the format of samples passed to STKFrameFilter blocks.
