### PR TITLE
Do not attempt to retrieve magic cookie from MP3 files.

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -2028,7 +2028,11 @@ static BOOL GetHardwareCodecClassDesc(UInt32 formatId, AudioClassDescription* cl
 
     audioConverterAudioStreamBasicDescription = *asbd;
     
-    if (self->currentlyReadingEntry.dataSource.audioFileTypeHint != kAudioFileAAC_ADTSType)
+    // Should probably be (self->currentlyReadingEntry.dataSource.audioFileTypeHint == kAudioFileAAC_ADTSType).
+    // Related issue https://github.com/tumtumtum/StreamingKit/issues/298
+    // MP3 files do not have magic cookies https://www.google.ch/patents/US20090019087
+    
+    if (self->currentlyReadingEntry.dataSource.audioFileTypeHint != kAudioFileAC3Type)
     {
         status = AudioFileStreamGetPropertyInfo(audioFileStream, kAudioFileStreamProperty_MagicCookieData, &cookieSize, &writable);
     


### PR DESCRIPTION
Related issue https://github.com/tumtumtum/StreamingKit/issues/298
[MP3 files do not have magic cookies](https://www.google.ch/patents/US20090019087) so an attempt to retrieve magic cookie from mp3 file causes method to return before the converter was created.

@tumtumtum please, review this change. It might be, that original intent was to check for `(self->currentlyReadingEntry.dataSource.audioFileTypeHint == kAudioFileAAC_ADTSType)` instead.