### PR TITLE
Fix playback after seek

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -1497,14 +1497,8 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         
         error = AudioFileStreamSeek(audioFileStream, seekPacket, &packetAlignedByteOffset, &ioFlags);
         
-        if (!error && !(ioFlags & kAudioFileStreamSeekFlag_OffsetIsEstimated))
+        if (!error && (ioFlags & kAudioFileStreamSeekFlag_OffsetIsEstimated))
         {
-            double delta = ((seekByteOffset - (SInt64)currentEntry->audioDataOffset) - packetAlignedByteOffset) / calculatedBitRate * 8;
-            
-            OSSpinLockLock(&currentEntry->spinLock);
-            currentEntry->seekTime -= delta;
-            OSSpinLockUnlock(&currentEntry->spinLock);
-            
             seekByteOffset = packetAlignedByteOffset + currentEntry->audioDataOffset;
         }
     }


### PR DESCRIPTION
Use estimated byte offset (if available) instead of calculated byte offset (Close #273).

#### Issue

I create `STKAudioPlayer` with URL to mp3 file. File duration is `38:05 (2285 s)`. After seeking to `37:40 (2260 s)`, player stopped.

#### Solution

After debugging player I figured out that offset is missing after seek: https://github.com/tumtumtum/StreamingKit/pull/329/commits/6d00aa0dfffdffec1e830409cc696b182db4ca84#diff-b23113711075e5d630996cbb4e38dfe7L1500

I guess it was a typo and I removed `!` before `(ioFlags & kAudioFileStreamSeekFlag_OffsetIsEstimated)`. But this caused another issue: seek started working as expected, but `progress` was off. 

For example after seeking to `37:40 (2260 s)`, `progress` was `37:15 (2235 s)`, not `37:40 (2260 s)`. The difference was exact value of [`delta` variable](https://github.com/tumtumtum/StreamingKit/pull/329/commits/6d00aa0dfffdffec1e830409cc696b182db4ca84#diff-b23113711075e5d630996cbb4e38dfe7L1502). So I removed this code and now it works as expected.

#### Important

I test this code only with mp3 files and I don't know how it'll work with other formats.