### PR TITLE
Revert "Fix playback after seek"

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -1497,8 +1497,14 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         
         error = AudioFileStreamSeek(audioFileStream, seekPacket, &packetAlignedByteOffset, &ioFlags);
         
-        if (!error && (ioFlags & kAudioFileStreamSeekFlag_OffsetIsEstimated))
+        if (!error && !(ioFlags & kAudioFileStreamSeekFlag_OffsetIsEstimated))
         {
+            double delta = ((seekByteOffset - (SInt64)currentEntry->audioDataOffset) - packetAlignedByteOffset) / calculatedBitRate * 8;
+            
+            OSSpinLockLock(&currentEntry->spinLock);
+            currentEntry->seekTime -= delta;
+            OSSpinLockUnlock(&currentEntry->spinLock);
+            
             seekByteOffset = packetAlignedByteOffset + currentEntry->audioDataOffset;
         }
     }


### PR DESCRIPTION
Reverts tumtumtum/StreamingKit#329

@tumtumtum I noticed that playback of some files become even more "broken" after this fix and rolled back to previous version in my project.

Sorry, I should've revert this PR when I found the issue.