### PR TITLE
Modify podspec line orders to fix 'Cannot synthesize weak property because the current deployment target does not support weak references'

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/tepmnthar/StreamingKit.git", :tag => s.version.to_s}
+  s.source       = { :git => "https://github.com/tumtumtum/StreamingKit.git", :tag => s.version.to_s}
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'
   s.ios.frameworks   = 'SystemConfiguration', 'CFNetwork', 'CoreFoundation', 'AudioToolbox'

--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "0.1.30"
+  s.version      = "0.1.31"
   s.platform     = :ios
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'

--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "0.1.31"
+  s.version      = "0.1.30"
+  s.platform     = :ios
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/tumtumtum/StreamingKit.git", :tag => s.version.to_s}
-  s.platform     = :ios
+  s.source       = { :git => "https://github.com/tepmnthar/StreamingKit.git", :tag => s.version.to_s}
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'
-  s.ios.deployment_target = '5.0'
   s.ios.frameworks   = 'SystemConfiguration', 'CFNetwork', 'CoreFoundation', 'AudioToolbox'
-  s.osx.deployment_target = '10.7'
   s.osx.frameworks   = 'SystemConfiguration', 'CFNetwork', 'CoreFoundation', 'AudioToolbox', 'AudioUnit'
 end


### PR DESCRIPTION
[reference](https://github.com/shu223/PulsingHalo/issues/42)