### PR TITLE
a wrong parameter

### DIFF
--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -2052,7 +2052,7 @@ static BOOL GetHardwareCodecClassDesc(UInt32 formatId, AudioClassDescription* cl
             return;
         }
         
-        status = AudioConverterSetProperty(audioConverterRef, kAudioConverterDecompressionMagicCookie, cookieSize, &cookieData);
+        status = AudioConverterSetProperty(audioConverterRef, kAudioConverterDecompressionMagicCookie, cookieSize, cookieData);
         
         if (status)
         {


### PR DESCRIPTION
There is a parameter error that causes thrown `STKAudioPlayerErrorAudioSystemError` when using magic cookies。this is apple documentation [How to handle audio data with magic cookie information](https://developer.apple.com/library/archive/qa/qa1318/_index.html)