### PR TITLE
fix: weird bleeps when playing a shoutcast stream

### DIFF
--- a/StreamingKit/StreamingKit/STKHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKHTTPDataSource.m
@@ -319,10 +319,11 @@
     }
     
     // check ICY headers
-    if ([httpHeaders objectForKey:@"Icy-metaint"] != nil)
+    NSString* icyHeaders = [httpHeaders objectForKey:@"Icy-Metaint"] ?: [httpHeaders objectForKey:@"icy-metaint"];
+    if (icyHeaders != nil)
     {
         _metadataBytesRead  = 0;
-        _metadataStep       = [[httpHeaders objectForKey:@"Icy-metaint"] intValue];
+        _metadataStep       = [icyHeaders intValue];
         _metadataOffset     = _metadataStep;
     }
 


### PR DESCRIPTION
Fixes #460

> When playing a SHOUTcast stream there are random bleeps occuring every x seconds and song metadata is not available.
> This happens for e.g. with:
> http://23.237.150.98:8512/ (PRM Internet Radio)
> http://lin1.san.fast-serv.com:9844/ (ANDYS 80S)
> 
> When playing those URL's with for e.g. Apple Music or VLC it plays without any bleeps and the currently played song is displayed.